### PR TITLE
Added configurationpossibilities

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -16,3 +16,6 @@ SilverStripe\Control\Director:
 #SilverStripe\CMS\Model\SiteTree:
 #  extensions:
 #    - XD\QRCodeGenerator\Extensions\SiteTreeExtension
+XD\QRCodeGenerator\Models\QRCode:
+  add_slash_on_qr_link: true
+  use_public_assets: true

--- a/src/Model/QRCode.php
+++ b/src/Model/QRCode.php
@@ -6,6 +6,8 @@ use chillerlan\QRCode\QROptions;
 use SilverStripe\Assets\Image;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\Debug;
 use SilverStripe\Forms\Form_FieldMap;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\LiteralField;
@@ -66,6 +68,9 @@ class QRCode extends DataObject
 
     public function getQRLink()
     {
+        if(Config::inst()->get(QRCode::class, 'add_slash_on_qr_link')) {
+            return Director::absoluteBaseURL() . '/qr/' . $this->ID;
+        }
         return Director::absoluteBaseURL() . 'qr/' . $this->ID;
     }
 
@@ -172,7 +177,11 @@ class QRCode extends DataObject
                 (new \chillerlan\QRCode\QRCode($options))->getMatrix($this->getQRLink())
             );
 
-            $logoFile = Director::baseFolder() . '/assets/' . $logo->getFilename();
+            if(Config::inst()->get(QRCode::class, 'use_public_assets')) {
+                $logoFile = Director::publicFolder() . '/assets/' . $logo->getFilename();
+            } else {
+                $logoFile = Director::baseFolder() . '/assets/' . $logo->getFilename();
+            }
 
             $qrcode = $qrOutputInterface->dump(
                 $file,

--- a/src/Model/QRCode.php
+++ b/src/Model/QRCode.php
@@ -7,7 +7,6 @@ use SilverStripe\Assets\Image;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\Dev\Debug;
 use SilverStripe\Forms\Form_FieldMap;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\LiteralField;


### PR DESCRIPTION
I have added a new feature that allows users to configure two settings via the config file. Firstly, you can now specify whether a slash should be included between the absoluteBaseURL and the 'qr/' route in the getQRLink function using the add_slash_on_qr_link configuration option. Additionally, you can control whether the public folder should be utilized for the generated QR code by using the use_public_assets configuration setting.